### PR TITLE
Set cmake_minimum_required to 3.5 for compatibility with cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(mbe)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 if(MSVC)
     # needed for M_PI macro


### PR DESCRIPTION
Set cmake_minimum_required to 3.5 for compatibility with cmake 4

https://cmake.org/cmake/help/v4.1/command/cmake_minimum_required.html

Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/v4.1/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/v4.1/command/cmake_policy.html#version) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce an error in CMake 4.0 and above.

